### PR TITLE
adding english study program names

### DIFF
--- a/uni-stuttgart-cs-cover.sty
+++ b/uni-stuttgart-cs-cover.sty
@@ -76,19 +76,31 @@
 	\gdef\@labelDept{Faculty of Computer Science}%
 	
 	\gdef\@labelTypeStudy{Studienarbeit}%
-	\gdef\@labelTypeDiplom{Diplomarbeit}%
-	\gdef\@labelTypeBachelor{Bachelorarbeit}%
-	\gdef\@labelTypeMaster{Masterarbeit}%
+	\gdef\@labelTypeDiplom{Diploma Thesis}%
+	\gdef\@labelTypeBachelor{Bachelor Thesis}%
+	\gdef\@labelTypeMaster{Master Thesis}%
 	\gdef\@labelTypeProjectINF{Projekt-INF}%
 	\gdef\@labelTypeFachstudie{Fachstudie}%
 	\gdef\@labelTypeProzessanalyse{Prozessanalyse}%
+	\gdef\@labelTypeNummer{No.}%
 	
-	\gdef\@labelCourseCS{Informatik}%
-	\gdef\@labelCourseSE{Softwaretechnik}%
-	\gdef\@labelCourseMCL{Computerlinguistik}%
-	\gdef\@labelCourseTK{Technische Kybernetik}%
-	\gdef\@labelCourseMSV{Maschinelle Sprachverarbeitung}%
-	\gdef\@labelCourseBIS{Wirtschaftsinformatik}%
+	\gdef\@labelCourseCS{Computer Science}%
+	\gdef\@labelCourseINF{Informatics}%  
+	% The old diploma study program in German is called "Computer Science"
+	% https://www.uni-stuttgart.de/studieren/angebot/studiengang/Computer_Science_Diploma_-_expiring/?__locale=en
+	% The bachelor study program in German is called "Informatics"
+	% https://www.uni-stuttgart.de/studieren/angebot/studiengang/Informatics_B.Sc./?__locale=en
+	% The master study program in German is called "Informatics"
+	% https://www.uni-stuttgart.de/studieren/angebot/studiengang/Informatics_M.Sc./?__locale=en
+	% The bachelor study program in German as minor subject is called "Computer Science"
+	% https://www.uni-stuttgart.de/studieren/angebot/studiengang/Computer_Science_B.A._xminor_subjectx/?__locale=en
+	% The master study program in English is called "Computer Science"
+	% https://www.uni-stuttgart.de/studieren/angebot/studiengang/Computer_Science_M.Sc._-_mainly_in_English/?__locale=en
+	\gdef\@labelCourseSE{Software Engineering}%
+	\gdef\@labelCourseMCL{Computational Linguistics}%
+	\gdef\@labelCourseTK{Technical Cybernetics}%
+	\gdef\@labelCourseMSV{Natural Language Processing}%
+	\gdef\@labelCourseBIS{Information Systems}% should better be "Business Informatics", but https://www.bwi.uni-stuttgart.de/wi/index.en.html says "Information Systems"
 	\gdef\@labelCourseSimTech{Simulation Technology}%
 	
 	% institute names
@@ -125,11 +137,13 @@
 	\gdef\@labelTypeDiplom{Diplomarbeit}%
 	\gdef\@labelTypeBachelor{Bachelorarbeit}%
 	\gdef\@labelTypeMaster{Masterarbeit}%
-	\gdef\@labelTypeProjectINF{Projekt-INF}%
+	\gdef\@labelTypeProjectINF{Project-INF}%
 	\gdef\@labelTypeFachstudie{Fachstudie}%
 	\gdef\@labelTypeProzessanalyse{Prozessanalyse}%
+	\gdef\@labelTypeNummer{Nr.}%
 	
 	\gdef\@labelCourseCS{Informatik}%
+	\gdef\@labelCourseINF{Informatik}%
 	\gdef\@labelCourseSE{Softwaretechnik}%
 	\gdef\@labelCourseMCL{Computerlinguistik}%
 	\gdef\@labelCourseTK{Technische Kybernetik}%
@@ -211,6 +225,7 @@
 	\def\1{\MCS@course}
 	% dont remove last two braces / empty else clause
 	\def\0{cs}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelCourseValue{\@labelCourseCS}}{}
+	\def\0{inf}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelCourseValue{\@labelCourseINF}}{}
 	\def\0{se}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelCourseValue{\@labelCourseSE}}{}
 	\def\0{mcl}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelCourseValue{\@labelCourseMCL}}{}
 	\def\0{msv}\ifthenelse{\equal{\0}{\1}}{\gdef\@labelCourseValue{\@labelCourseMSV}}{}
@@ -304,7 +319,7 @@
     \vbox to 60mm{\hsize=95mm\parindent=0pt
       \vskip 10mm plus 30mm minus 7.5mm
       \begin{center}\@setsize\large{14pt}\xiipt\@xiipt %%\large
-        \@labelType\ Nr.\,\MCS@number
+        \@labelType\ \@labelTypeNummer\,\MCS@number
       \end{center}%
       \vskip 12.5mm plus 12.5mm minus 10mm
       \begin{center}\@setsize\LARGE{22pt}\xviipt\@xviipt %%\LARGE


### PR DESCRIPTION
Sollten in der englischen Variante nicht auch die englischen Namen für die Studiengänge (bspw. 'Computer Science') sowie für die Arbeiten (bspw. 'Diploma Thesis', 'Master Thesis',..) verwendet werden? Gleichzeitig sollte 'Nr.' und 'No.' variabel sein, je nach gewählter Sprache.
Ich konnte leider nicht alles übersetzen, da ich kein englisches Äquivalent finden konnte (Fachstudie z.B.).

Informatik Bachelor/Master ist besonders eklig, da die Uni Stuttgart da tatsächlich verschiedene englische Namen je nach Studiengangsprache und Abschluss gewählt hat. Auch ob Neben- oder Hauptfach spielt eine Rolle. Siehe Kommentare im Quellcode.

Oder hat das einen Grund dass das explizit Deutsch bleibt? Sollte man das erst noch mit Frau Ritzmann abklären? 

(Beispiel für eine englische Arbeit in der komplett die englischen Bezeichnungen verwendet werden: http://www2.informatik.uni-stuttgart.de/cgi-bin/NCSTRL/NCSTRL_view.pl?id=DIP-3564&mod=0&engl=0&inst=FAK)

(analog zum template)