### PR TITLE
get example supervisors consistent with template

### DIFF
--- a/thesis.tex
+++ b/thesis.tex
@@ -13,7 +13,7 @@
 	number=12345,
 	course=se,
 	examiner={Prof.\ Dr.\ Hans Mustermann},
-	supervisor={Otto Normalverbraucher, M.Sc.},
+	supervisor={Dipl.-Inf.\ Roman Tiker,\\Dipl.-Inf.\ Laura Stern,\\Otto Normalverbraucher,\ M.Sc.},
 	startdate={2012-06-01},
 	enddate={2012-12-01},
 	crk={I.7.2},


### PR DESCRIPTION
Einige Studenten schreiben "M.Sc. Name", was sowohl im englischen als auch im deutschen falsch bzw. unüblich ist. Es muss "Name, M.Sc." heißen. Könnte man mit einem besseren Beispiel vllt. etwas in der Welt der akademischen Titel bewegen?

Auf gleichem Wege habe ich die Beispiele zwischen den beiden Repositories (Template und Cover) angepasst.

siehe: 
> Allgemein üblich ist aber, dass Diplom- und Doktorgrade vor dem Namen, Magister- und Bachelor-/Master-/PhD-Grade hinter dem Namen geführt werden.
(https://de.wikipedia.org/wiki/Akademischer_Grad#Form_der_F.C3.BChrung)
> There are various conventions for indicating degrees and diplomas **after one's name**.
(https://en.wikipedia.org/wiki/Academic_degree#Indicating_earned_degrees)